### PR TITLE
upgrade scrollable_positioned_list to v0.1.8 for sticky header fix

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  scrollable_positioned_list: ^0.1.7
+  scrollable_positioned_list: ^0.1.8
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Hello, 
I had a problem with sticky_grouped_list in that on the first load of data, the first sticky header would be extra sticky, i.e. it did not update when scrolling to the next group. I could pinpoint the issue in the upstream library scrollable_positioned_list, see https://github.com/google/flutter.widgets/issues/182 . This has now been fixed in the latest version v0.1.8, so I suggest to update the min requirement.

cheers
matthias