### PR TITLE
avoid reduce when a list is empty

### DIFF
--- a/lib/src/sticky_grouped_list.dart
+++ b/lib/src/sticky_grouped_list.dart
@@ -309,19 +309,21 @@ class StickyGroupedListViewState<T, E>
       return current.itemTrailingEdge < pos.itemTrailingEdge ? current : pos;
     }
 
-    ItemPosition currentItem = _listener.itemPositions.value
+    final group = _listener.itemPositions.value
         .where((ItemPosition position) =>
             !_isSeparator!(position.index) &&
-            position.itemTrailingEdge > headerDimension!)
-        .reduce(reducePositions);
+            position.itemTrailingEdge > headerDimension!);
+    if (group.isNotEmpty) {        
+      ItemPosition currentItem = group.reduce(reducePositions);
 
-    int index = currentItem.index ~/ 2;
-    if (_topElementIndex != index) {
-      E curr = widget.groupBy(sortedElements[index]);
-      E prev = widget.groupBy(sortedElements[_topElementIndex]);
-      if (prev != curr) {
-        _topElementIndex = index;
-        _streamController.add(_topElementIndex);
+      int index = currentItem.index ~/ 2;
+      if (_topElementIndex != index) {
+        E curr = widget.groupBy(sortedElements[index]);
+        E prev = widget.groupBy(sortedElements[_topElementIndex]);
+        if (prev != curr) {
+          _topElementIndex = index;
+          _streamController.add(_topElementIndex);
+        }
       }
     }
   }


### PR DESCRIPTION

Hi, we have an exception when trying to run "reduce" on an empty list.